### PR TITLE
Depcrecated trim

### DIFF
--- a/src/mod_tablemakerforcsv.php
+++ b/src/mod_tablemakerforcsv.php
@@ -40,7 +40,7 @@ if ($params->get('moduleclass_sfx') !== "") {
     $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
 }
 
-if ($captions !== "") {
+if (!empty($captions)) {
     if (trim($captions)!=="") {
         $caption=explode('@#',$captions);
     }

--- a/src/tmpl/default.php
+++ b/src/tmpl/default.php
@@ -67,7 +67,7 @@ if ($lookup || $pagination) {
 }
 
 // The template
-if ($pretext !== "") {
+if (!empty($pretext)) {
   if (trim($pretext)!=="") {
     echo '<div class="pretext">'.$pretext.'</div>';
   }
@@ -84,7 +84,7 @@ if ($fileurl!=="") {
 
     echo '<table class="csvtable'.$moduleclass_sfx.'" id="csvtable">';
 
-    if ($captions !== "") {
+    if (!empty($captions)) {
       if (trim($captions)!=="") {
         echo '<tr>';
         $end = count($caption);
@@ -116,7 +116,7 @@ if ($fileurl!=="") {
   }
 }
 
-if ($posttext !== "") {
+if (!empty($posttext)) {
   if (trim($posttext)!=="") {
     echo '<div class="posttext">'.$posttext.'</div>';
   }


### PR DESCRIPTION
Correct check for null or empty strings before trimming to prevent deprecated message