### PR TITLE
Update default.php : problem when adding a class suffix in the module

### DIFF
--- a/src/tmpl/default.php
+++ b/src/tmpl/default.php
@@ -18,24 +18,24 @@ if ($pagination) {
 
 // Custom CSS
 if ($styling) {
-  $style=".csvtable".$moduleclass_sfx."{
+  $style=".csvtable".str_replace(' ','.',$moduleclass_sfx)."{
     text-align:".$textalign.";
     font:".$tablefont.";
     border-radius:".$borderradius.";
     ".$table_style."
 }
-.csvtable".$moduleclass_sfx." th,.csvtable".$moduleclass_sfx." td{
+.csvtable".str_replace(' ','.',$moduleclass_sfx)." th,.csvtable".str_replace(' ','.',$moduleclass_sfx)." td{
 padding:".$padding.";
 }
-.csvtable".$moduleclass_sfx." tr th,.csvtable".$moduleclass_sfx." tr th a{
+.csvtable".str_replace(' ','.',$moduleclass_sfx)." tr th,.csvtable".str_replace(' ','.',$moduleclass_sfx)." tr th a{
 background:".$firstrow_bg.";
 color:".$firstrow_color.";
 font:".$firstrow_font.";
 }
-.csvtable".$moduleclass_sfx." tr:nth-child(even) td{
+.csvtable".str_replace(' ','.',$moduleclass_sfx)." tr:nth-child(even) td{
     background: ".$evenbg.";
 }
-.csvtable".$moduleclass_sfx." tr:nth-child(odd) td{
+.csvtable".str_replace(' ','.',$moduleclass_sfx)." tr:nth-child(odd) td{
     background: ".$oddbg.";
 }
 #csvpagination a{


### PR DESCRIPTION
I had forgotten about this problem in the module: in case of adding one or more classes, there is no . in front of the classes and these are not correctly written in the style definition. This results in an error and affected styles are not applied.

I patched the mostafa's module by replacing '$moduleclass_sfx' with 'str_replace(' ','.',$moduleclass_sfx)' except on line 88. My patch has one problem: the first (or only) class must start with a space.